### PR TITLE
added run daily alert script & integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,18 @@ python -m scripts.seed_db
 uvicorn app.main:app --reload
 ```
 
+
 Open:
 - API docs: http://127.0.0.1:8000/docs
 - Demo UI:   http://127.0.0.1:8000/
+
+### Run the daily alert demo (offline & deterministic)
+
+To simulate a 'newly risky today' pipeline end to end (seed → trends → cross-match → alerts) without any network dependency:
+
+```bash
+python -m scripts.run_daily_alerts --source snapshot
+```
 
 ---
 
@@ -95,10 +104,19 @@ See `data/EXTERNAL_DATASETS.md` for recommended open‑licensed alternatives and
 ---
 
 ## 6) Tests
+
+
+
+Run unit + integration tests:
+
 ```bash
 pytest -q
 ```
+Run integration tests alone
 
+```bash
+pytest -q -k integration
+```
 ---
 
 ## 7) Repo structure

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 pythonpath = .
 testpaths = tests
+markers =
+    integration: integration-style API flow tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ vaderSentiment==3.3.2
 python-dateutil==2.9.0.post0
 pytest==8.1.1
 pandas==2.2.2
+httpx==0.27.0

--- a/scripts/run_daily_alerts.py
+++ b/scripts/run_daily_alerts.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from app.core.db import init_db, get_session
+from app.core.matching import run_cross_match
+from app.core.models import TrendTopic
+from scripts.seed_db import parse_dt, main as seed_main
+
+
+def upsert_snapshot_trends(snapshot_path: str) -> int:
+    """
+    Offline ingest helper: load data/trends_snapshot_today.json and upsert TrendTopic rows
+    Avoids any network/API dependency and does not require Issue 3 prerequisite
+    """
+    p = Path(snapshot_path)
+    if not p.exists():
+        raise FileNotFoundError(f"Snapshot trends file not found: {snapshot_path}")
+
+    snap = json.loads(p.read_text(encoding="utf-8"))
+    trends = snap.get("trends", [])
+
+    updated = 0
+    with get_session() as session:
+        for t in trends:
+            term = t["term"]
+            existing = session.get(TrendTopic, term)
+
+            obj = TrendTopic(
+                term=term,
+                volume=int(t["volume"]),
+                tone=float(t.get("tone", 0.0)),
+                last_seen=parse_dt(t.get("last_seen")),
+                source="sample_snapshot",
+            )
+
+            if existing:
+                existing.volume = obj.volume
+                existing.tone = obj.tone
+                existing.last_seen = obj.last_seen
+                existing.source = obj.source
+            else:
+                session.add(obj)
+
+            updated += 1
+
+        session.commit()
+
+    return updated
+
+
+def _print_summary(created_count: int, alerts: List[Any]) -> None:
+    print(f"Alerts created: {created_count}")
+    for a in alerts[:3]:
+        # a is an Alert model
+        print(
+            f"- item_id={a.item_id} term={a.trend_term} {a.old_bucket} -> {a.new_bucket} delta={a.risk_delta}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Daily demo pipeline: trends -> cross-match -> alerts")
+    parser.add_argument("--source", choices=["snapshot", "rss", "newsapi"], default="snapshot")
+    parser.add_argument("--limit-items", type=int, default=200)
+    parser.add_argument(
+        "--snapshot-path",
+        default=str(Path(__file__).resolve().parents[1] / "data" / "trends_snapshot_today.json"),
+    )
+    args = parser.parse_args()
+    init_db()
+    seed_main()
+    if args.source == "snapshot":
+        n = upsert_snapshot_trends(args.snapshot_path)
+        print(f"Ingested snapshot trends: {n}")
+    else:
+        os.environ["TRENDS_SOURCE"] = args.source
+        print(f"Using live trends source: {args.source} (run POST /trends/ingest manually)")
+
+    created_count, created_alerts = run_cross_match(limit_items=args.limit_items)
+    _print_summary(created_count, created_alerts)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api_flow.py
+++ b/tests/test_api_flow.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _reload_app_modules():
+    """
+    app.core.db creates the SQLModel engine at import time from DATABASE_URL
+    """
+    for m in [
+        "app.core.db",
+        "app.main",
+        "scripts.seed_db",
+    ]:
+        if m in sys.modules:
+            del sys.modules[m]
+
+
+@pytest.mark.integration
+def test_alerts_flow_offline_snapshot(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("TRENDS_SOURCE", "rss")
+    monkeypatch.delenv("NEWSAPI_KEY", raising=False)
+
+    _reload_app_modules()
+    import app.main as main_mod
+    import scripts.seed_db as seed_mod
+    seed_mod.main()
+
+    client = TestClient(main_mod.app)
+    r = client.get("/trends/current")
+    assert r.status_code == 200
+    body = r.json()
+    assert "trends" in body
+    assert body["count"] >= 1
+    r = client.post("/alerts/run", params={"limit_items": 200})
+    assert r.status_code == 200
+    run_body = r.json()
+    assert "created" in run_body
+    r = client.get("/alerts", params={"limit": 50})
+    assert r.status_code == 200
+    out = r.json()
+    assert "alerts" in out
+    assert "count" in out
+    assert isinstance(out["alerts"], list)
+    if out["alerts"]:
+        a = out["alerts"][0]
+        for k in ["id", "created_at", "trend_term", "old_bucket", "new_bucket", "risk_delta", "item_id", "details"]:
+            assert k in a
+
+
+@pytest.mark.integration
+def test_risk_items_endpoint_works_offline(tmp_path, monkeypatch):
+    db_path = tmp_path / "test2.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.delenv("NEWSAPI_KEY", raising=False)
+
+    _reload_app_modules()
+
+    import app.main as main_mod
+    import scripts.seed_db as seed_mod
+
+    seed_mod.main()
+    client = TestClient(main_mod.app)
+
+    r = client.get("/risk/items", params={"limit": 5, "include_trends": True})
+    assert r.status_code == 200
+    body = r.json()
+    assert "items" in body
+    assert body["count"] >= 1
+    it = body["items"][0]
+    assert "risk" in it
+    assert "bucket" in it["risk"]
+    assert "reasons" in it["risk"]
+    assert "decomposition" in it["risk"]


### PR DESCRIPTION
 solves issue 5 #4 
added

* `scripts/run_daily_alerts.py`

   * seed DB → ingest snapshot trends → run cross-match → print alert summary
   * Fully offline
* `tests/test_api_flow.py`

  * Integration tests using `TestClient`
  * Isolated temp SQLite DB per test
  * Validates `/alerts/run`, `/alerts`, `/trends/current`, and `/risk/items` flow
* `httpx` with version added in `requirements.txt`
* README updated with daily demo command and integration test note
